### PR TITLE
Add a generic endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,14 @@ $ curl --silent 'localhost:8080/lookup?address=1100+Congress+Ave&city=austin&sta
 }
 ```
 
+Deploying this
+--------------
+
+This is meant for private use and deployed locally. Eventually, I might
+document putting it behind an API gateway to lock down access. See
+`example.env` for what environment variables you'll need.
+
 ### Docker
 
 See the `docker-compose.yml` and `Dockerfile` for more examples on how to run
 this.
-
-
-## Deployment
-
-This is meant for private use and deployed locally. Eventually, I might
-document putting it behind an API gateway to lock down access.

--- a/README.md
+++ b/README.md
@@ -26,23 +26,74 @@ Query with these get parameters:
 * zip
 
 
-### Example
+Examples
+--------
+
+Querying one location backend:
 
 ```
-$ curl 'localhost:8080/tamu?address=1100+Congress+Ave&city=austin&state=tx&zip=78701' | jq .
+$ curl --silent 'localhost:8080/lookup/tamu?address=1100+Congress+Ave&city=austin&state=tx&zip=78701' | jq .
 {
+  "type": "Feature",
+  "properties": {
+    "quality": "03",
+    "timestamp": "2016-12-10T03:50:25.123063Z",
+    "cached": true
+  },
   "geometry": {
+    "type": "Point",
     "coordinates": [
       "-97.740133410666",
       "30.2754538274838"
-    ],
-    "type": "Point"
-  },
+    ]
+  }
+}
+```
+
+Querying the generic endpoint:
+
+```
+$ curl --silent 'localhost:8080/lookup?address=1100+Congress+Ave&city=austin&state=tx&zip=78701' | jq .
+{
+  "type": "Feature",
   "properties": {
-    "timestamp": "2016-12-03T03:42:37.605378Z",
-    "quality": "03"
+    "quality": "03",
+    "timestamp": "2016-12-10T03:52:18.988198Z",
+    "cached": true
   },
-  "type": "Feature"
+  "geometry": {
+    "type": "Point",
+    "coordinates": [
+      "-97.740133410666",
+      "30.2754538274838"
+    ]
+  }
+}
+```
+
+Querying the generic endpoint with no analysis, `return=collection`:
+
+```
+$ curl --silent 'localhost:8080/lookup?address=1100+Congress+Ave&city=austin&state=tx&zip=78701&return=collection' | jq .
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "quality": "03",
+        "timestamp": "2016-12-10T03:53:08.280099Z",
+        "cached": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          "-97.740133410666",
+          "30.2754538274838"
+        ]
+      }
+    }
+  ]
 }
 ```
 

--- a/server.py
+++ b/server.py
@@ -121,12 +121,12 @@ async def lookup(request):
 
     tamu_feature = await get_from_tamu(address_components)
 
-    if True:
-        # TODO average lookups
-        data = tamu_feature
-    else:
+    if request.GET.get('return') == 'collection':
         # TODO support multiple points if users requests
         data = FeatureCollection([tamu_feature])
+    else:
+        # TODO average lookups
+        data = tamu_feature
 
     text = json.dumps(data, cls=DjangoJSONEncoder)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -45,7 +45,7 @@ async def test_lookup(test_client, loop):
     app = make_app(loop=loop)
     client = await test_client(app)
 
-    mock_get = AsyncMock(return_value=[{'foo': 'bar'}, False])
+    mock_get = AsyncMock(return_value={'foo': 'bar'})
 
     with patch('server.get_from_tamu', new=mock_get):
         resp = await client.get('/lookup', params={

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,7 +10,7 @@ async def test_tamu_lookup_errors_with_bad_input(test_client, loop):
     app = make_app(loop=loop)
     client = await test_client(app)
 
-    resp = await client.get('/tamu')
+    resp = await client.get('/lookup/tamu')
 
     assert resp.status == 400
 
@@ -25,7 +25,7 @@ async def test_tamu_lookup(test_client, loop):
 
     with patch('utils.tamu.requests.get') as mock_get:
         mock_get.return_value = mock_response
-        resp = await client.get('/tamu', params={
+        resp = await client.get('/lookup/tamu', params={
             'address': '1100 Congress Ave',
             'city': 'austin',
             'state': 'tx',

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -41,7 +41,7 @@ async def test_tamu_lookup(test_client, loop):
     assert resp.headers['Content-Type'] == 'application/json; charset=utf-8'
 
 
-async def test_lookup(test_client, loop):
+async def test_lookup_returns_service_response(test_client, loop):
     app = make_app(loop=loop)
     client = await test_client(app)
 
@@ -59,6 +59,27 @@ async def test_lookup(test_client, loop):
     assert resp.status == 200
     assert resp.headers['Content-Type'] == 'application/json; charset=utf-8'
     assert out == {'foo': 'bar'}
+
+
+async def test_lookup_returns_all_service_responses(test_client, loop):
+    app = make_app(loop=loop)
+    client = await test_client(app)
+
+    mock_get = AsyncMock(return_value={'foo': 'bar'})
+
+    with patch('server.get_from_tamu', new=mock_get):
+        resp = await client.get('/lookup', params={
+            'address': '1100 Congress Ave',
+            'city': 'austin',
+            'state': 'tx',
+            'zip': '78701',
+            'return': 'collection',
+        })
+    out = await resp.json()
+
+    assert resp.status == 200
+    assert resp.headers['Content-Type'] == 'application/json; charset=utf-8'
+    assert out == {'features': [{'foo': 'bar'}], 'type': 'FeatureCollection'}
 
 
 async def test_metrics(test_client, loop):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,6 +6,11 @@ from server import make_app
 TAMU_SUCCESS= '139863c0-e12d-4ace-a0aa-7ad84ca88a4e,4.1,200,30.2754538274838,-97.740133410666,03,StreetSegmentInterpolation,100,Exact,Success,1,StreetSegment,1602.31620959309,Meters,LOCATION_TYPE_STREET_ADDRESS,0.0120012,'  # noqa
 
 
+class AsyncMock(MagicMock):
+    async def __call__(self, *args, **kwargs):
+        return super(AsyncMock, self).__call__(*args, **kwargs)
+
+
 async def test_tamu_lookup_errors_with_bad_input(test_client, loop):
     app = make_app(loop=loop)
     client = await test_client(app)
@@ -34,6 +39,26 @@ async def test_tamu_lookup(test_client, loop):
 
     assert resp.status == 200
     assert resp.headers['Content-Type'] == 'application/json; charset=utf-8'
+
+
+async def test_lookup(test_client, loop):
+    app = make_app(loop=loop)
+    client = await test_client(app)
+
+    mock_get = AsyncMock(return_value=[{'foo': 'bar'}, False])
+
+    with patch('server.get_from_tamu', new=mock_get):
+        resp = await client.get('/lookup', params={
+            'address': '1100 Congress Ave',
+            'city': 'austin',
+            'state': 'tx',
+            'zip': '78701',
+        })
+    out = await resp.json()
+
+    assert resp.status == 200
+    assert resp.headers['Content-Type'] == 'application/json; charset=utf-8'
+    assert out == {'foo': 'bar'}
 
 
 async def test_metrics(test_client, loop):


### PR DESCRIPTION
so the requesting library is agnostic to what backend to use.

when returning, it will return just a point, but with `return=collection`, get all the points back